### PR TITLE
Abstract out namespaces to support DevTest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,7 @@ jobs:
       run: |
         for N in ${{ steps.get_images.outputs.NAMES }}
         do
-          TAGGED_IMAGE="${{ secrets.DOCKER_NAMESPACE }})/$(basename ${N}):${{ steps.publish_tag.outputs.TAG }}"
+          TAGGED_IMAGE="${{ secrets.DOCKER_NAMESPACE }}/$(basename ${N}):${{ steps.publish_tag.outputs.TAG }}"
           docker buildx build \
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
             --push \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,9 @@ name: buildx
 
 on:
   push:
-    branches: master
+    branches:
+      - master
+      - develop
     tags: 'v*'
 
 jobs:
@@ -12,59 +14,111 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Get the version
+      with:
+        fetch-depth: 0
+    - name: Define list of images to build
+      id: get_images
+      run: |
+        echo ::set-output name=NAMES::${NAMES}
+      env:
+        NAMES: mercury network_tap/ncapture network_tap p0f pcap_stats pcap_to_node_pcap tcprewrite_dot1q snort
+    - name: Get version number
       id: get_version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-    - name: Change for master
-      id: change_version
-      run: if [ "${{ steps.get_version.outputs.VERSION }}" == "master" ]; then echo ::set-output name=VERSION::latest; else echo ::set-output name=VERSION::${{ steps.get_version.outputs.VERSION }}; fi
+      run: |
+        VERSION=$(git describe --tags)
+        echo VERSION=${VERSION}
+        echo ::set-output name=VERSION::${VERSION}
+
+        TAG_VERSION=$(git describe --abbrev=0 --tags)
+        echo TAG_VERSION=${TAG_VERSION}
+        echo ::set-output name=TAG_VERSION::${TAG_VERSION}
+
+        if [[ ${VERSION} == ${TAG_VERSION} ]] ||
+           [[ "${GITHUB_REF##*/}" == "master" ]]; then
+          IS_RELEASE="true"
+        else
+          IS_RELEASE="false"
+        fi
+        echo IS_RELEASE=${IS_RELEASE}
+        echo ::set-output name=IS_RELEASE::${IS_RELEASE}
+    - name: Should this workflow push to Docker Hub?
+      id: docker
+      env:
+        DOCKER_PASSWORD:  ${{ secrets.DOCKER_TOKEN }}
+        DOCKER_USERNAME:  ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_NAMESPACE:  ${{ secrets.DOCKER_NAMESPACE }}
+      run: |
+        PUSH_TO_DOCKER="false"
+        if [[ "${{ github.event_name }}" == "push" ]] &&
+           [[ "${{ steps.get_version.outputs.IS_RELEASE }}" == "true" ]]
+        then
+          # Must define all three variables for Docker Hub publishing to work
+          [[ -z "$DOCKER_USERNAME" ]] && (echo "Must define secret: DOCKER_USERNAME"; exit 1)
+          [[ -z "$DOCKER_PASSWORD" ]] && (echo "Must define secret: DOCKER_PASSWORD"; exit 1)
+          [[ -z "$DOCKER_NAMESPACE" ]] && (echo "Must define secret: DOCKER_NAMESPACE"; exit 1)
+          PUSH_TO_DOCKER="true"
+        fi
+        echo ::set-output name=PUSH_TO_DOCKER::${PUSH_TO_DOCKER}
+        echo PUSH_TO_DOCKER=${PUSH_TO_DOCKER}
+    - name: Change tag for release on master branch
+      id: publish_tag
+      run: |
+        echo GITHUB_REF=${GITHUB_REF}
+        echo 'GITHUB_REF##*/'=${GITHUB_REF##*/}
+        if [[ "${GITHUB_REF##*/}" == "master" ]]; then
+          echo ::set-output name=TAG::latest;
+          echo TAG=latest
+        else
+          echo ::set-output name=TAG::${VERSION};
+          echo TAG=${VERSION}
+        fi
+      env:
+        VERSION: ${{ steps.get_version.outputs.VERSION }}
+    - name: Test building only
+      run: |
+        for N in ${{ steps.get_images.outputs.NAMES }}
+        do
+          docker build ${N}
+        done
+      if: steps.docker.outputs.PUSH_TO_DOCKER == 'false'
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v3
       with:
         buildx-version: latest
         qemu-version: latest
+      if: success() && (steps.docker.outputs.PUSH_TO_DOCKER == 'true')
     - name: Docker Login
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
       run: |
         echo "${DOCKER_PASSWORD}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      if: github.repository == 'iqtlabs/network-tools' && github.event_name == 'push'
-
+      if: success() && (steps.docker.outputs.PUSH_TO_DOCKER == 'true')
     - name: Build and push platforms
       env:
         DOCKER_CLI_EXPERIMENTAL: enabled
       run: |
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/mercury:${{ steps.change_version.outputs.VERSION }} mercury && \
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/ncapture:${{ steps.change_version.outputs.VERSION }} network_tap/ncapture && \
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/network-tap:${{ steps.change_version.outputs.VERSION }} network_tap && \
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/p0f:${{ steps.change_version.outputs.VERSION }} p0f && \
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/pcap-stats:${{ steps.change_version.outputs.VERSION }} pcap_stats && \
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/pcap-to-node-pcap:${{ steps.change_version.outputs.VERSION }} pcap_to_node_pcap && \
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/tcprewrite-dot1q:${{ steps.change_version.outputs.VERSION }} tcprewrite_dot1q && \
-        docker buildx build \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --push \
-          -t iqtlabs/snort:${{ steps.change_version.outputs.VERSION }} snort
-      if: github.repository == 'iqtlabs/network-tools' && github.event_name == 'push'
+        for N in ${{ steps.get_images.outputs.NAMES }}
+        do
+          TAGGED_IMAGE="${{ secrets.DOCKER_NAMESPACE }})/$(basename ${N}):${{ steps.publish_tag.outputs.TAG }}"
+          docker buildx build \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 \
+            --push \
+            -t ${TAGGED_IMAGE} ${N}
+        done
+      if: success() && (steps.docker.outputs.PUSH_TO_DOCKER == 'true')
+    - name: List available tags for images
+      env:
+        DOCKER_CLI_EXPERIMENTAL: enabled
+      run: |
+        for N in ${{ steps.get_images.outputs.NAMES }}
+        do
+          image="${{ secrets.DOCKER_NAMESPACE }}/$(basename ${N})"
+          echo "${image}:" $(
+            wget -q https://registry.hub.docker.com/v1/repositories/${image}/tags -O - |
+              tr -d '[]" ' |
+              tr '}' '\n' |
+              awk -F: '{printf $3 " "}'
+          )
+        done
+      if: success() && (steps.docker.outputs.PUSH_TO_DOCKER == 'true')

--- a/tcprewrite_dot1q/Dockerfile
+++ b/tcprewrite_dot1q/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.12
 LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
@@ -20,7 +20,10 @@ COPY tcprewrite.py tcprewrite.py
 RUN curl -L https://github.com/appneta/tcpreplay/releases/download/v4.3.2/tcpreplay-4.3.2.tar.gz -o tcpreplay-4.3.2.tar.gz
 RUN tar -xf tcpreplay-4.3.2.tar.gz
 RUN cp en10mb.c tcpreplay-4.3.2/src/tcpedit/plugins/dlt_en10mb/en10mb.c
-RUN cd tcpreplay-4.3.2 && ./configure && make && make install
+RUN cd tcpreplay-4.3.2 && \
+    if ! ./configure; then cat config.log; exit 1; fi && \
+    make && \
+    make install
 
 ENTRYPOINT ["python3", "tcprewrite.py"]
 CMD [""]


### PR DESCRIPTION
This pull request contains the same abstraction in the GitHub workflow as the `packet_cafe` repo to allow other accounts to execute the workflow and publish images to Docker Hub.

In the process of testing this, I ran into a problem with compilation failures in the `tcprewrite_dot1q/Dockerfile` that resulted from the `alpine:edge` release upgrading Gcc to v10. I backed off one version to get GCC v9, which compiles fine. (The `if` statement in the `make` sequence will print out the `config.log` file before exiting on failure to help debug the container build.) 